### PR TITLE
feat: implement validation middleware for request parameters and body

### DIFF
--- a/webhook-service/src/middleware/validation.ts
+++ b/webhook-service/src/middleware/validation.ts
@@ -1,0 +1,33 @@
+import type { Context, Next } from 'hono';
+import type { ZodSchema } from 'zod';
+
+// Attach validated JSON body to context
+export function validateBody(schema: ZodSchema<any>) {
+  return async (c: Context, next: Next) => {
+    try {
+      const json = await c.req.json();
+      const data = schema.parse(json);
+      c.set('validatedBody', data);
+      return next();
+    } catch (err: any) {
+      return c.json({ error: 'Invalid request body', details: err.errors }, 400);
+    }
+  };
+}
+
+// Attach validated params to context
+export function validateParams(schema: ZodSchema<any>) {
+  return async (c: Context, next: Next) => {
+    try {
+      const rawParams: Record<string, string> = {};
+      Object.keys((schema as any).shape).forEach((key: string) => {
+        rawParams[key] = c.req.param(key);
+      });
+      const params = schema.parse(rawParams);
+      c.set('validatedParams', params);
+      return next();
+    } catch (err: any) {
+      return c.json({ error: 'Invalid URL parameters', details: err.errors }, 400);
+    }
+  };
+}

--- a/webhook-service/src/routes/settings.routes.ts
+++ b/webhook-service/src/routes/settings.routes.ts
@@ -1,19 +1,40 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import { SettingsController } from '../controllers/SettingsController';
+import { validateParams, validateBody } from '../middleware/validation';
+import { settingInputSchema } from '../validators/settings.validators';
 
 const settingsRoutes = new Hono();
 const settingsController = new SettingsController();
 
 // Get all settings for a user
-settingsRoutes.get('/settings/:userId', (c) => settingsController.getAll(c));
+settingsRoutes.get(
+  '/settings/:userId',
+  validateParams(z.object({ userId: z.string().uuid() })),
+  (c) => settingsController.getAll(c)
+);
 
-// Create or update a setting
-settingsRoutes.post('/settings/:userId', (c) => settingsController.create(c));
+// Create or upsert a setting
+settingsRoutes.post(
+  '/settings/:userId',
+  validateParams(z.object({ userId: z.string().uuid() })),
+  validateBody(settingInputSchema),
+  (c) => settingsController.create(c)
+);
 
 // Update an existing setting by ID
-settingsRoutes.put('/settings/:userId/:id', (c) => settingsController.update(c));
+settingsRoutes.put(
+  '/settings/:userId/:id',
+  validateParams(z.object({ userId: z.string().uuid(), id: z.string().uuid() })),
+  validateBody(settingInputSchema),
+  (c) => settingsController.update(c)
+);
 
 // Delete a setting by ID
-settingsRoutes.delete('/settings/:userId/:id', (c) => settingsController.remove(c));
+settingsRoutes.delete(
+  '/settings/:userId/:id',
+  validateParams(z.object({ userId: z.string().uuid(), id: z.string().uuid() })),
+  (c) => settingsController.remove(c)
+);
 
 export default settingsRoutes;


### PR DESCRIPTION
updated Zod validators, and Hono routes for CRUD and tested it 
This pull request introduces middleware for validating request bodies and parameters using `zod` schemas in the `webhook-service`. It also integrates this middleware into the settings routes to ensure data validation for incoming requests. These changes improve the robustness and maintainability of the code by enforcing strict validation at the API layer.

### Middleware for validation:
* [`webhook-service/src/middleware/validation.ts`](diffhunk://#diff-d9b7271c5ea8e3c63de7e191d3b71a346be2fd284e2ff330aa82dd14bb7a7044R1-R33): Added `validateBody` and `validateParams` functions to validate JSON request bodies and URL parameters using `zod` schemas. Validated data is attached to the context for downstream usage, and meaningful error responses are returned for invalid inputs.

### Integration with settings routes:
* [`webhook-service/src/routes/settings.routes.ts`](diffhunk://#diff-3f3266d8807fa542be5be631acaf6851906a4403b0bfad7fd51a148c1d75cd8fR2-R38): Updated all routes in `settingsRoutes` to use the new validation middleware (`validateBody` and `validateParams`) with appropriate `zod` schemas. This ensures that request bodies and parameters are validated before reaching the controller logic.
