### PR TITLE
feat: add IP validation middleware for M-Pesa requests

### DIFF
--- a/webhook-service/package.json
+++ b/webhook-service/package.json
@@ -22,7 +22,8 @@
     "hono": "^4.8.3",
     "jose": "^6.0.11",
     "pg": "^8.16.2",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "ip-cidr": "^4.0.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/webhook-service/src/middleware/ipValidator.ts
+++ b/webhook-service/src/middleware/ipValidator.ts
@@ -1,0 +1,54 @@
+import type { Context, Next } from 'hono';
+import CIDR from 'ip-cidr';
+
+// Load allowed M-Pesa IP ranges from environment variable (comma-separated CIDRs)
+const MPESA_IP_RANGES = (process.env.MPESA_IP_RANGES || '')
+  .split(',')
+  .map(r => r.trim())
+  .filter(Boolean);
+
+// Validate configuration at startup
+if (MPESA_IP_RANGES.length === 0) {
+  console.warn(
+    '⚠️ MPESA_IP_RANGES is empty - IP validation will block all non-health requests'
+  );
+}
+
+/**
+ * IP validation middleware: only allow requests from configured M-Pesa IP ranges.
+ */
+export async function ipValidator(c: Context, next: Next) {
+  // Skip IP validation for health and status endpoints
+  const reqUrl = new URL(c.req.url);
+  if (reqUrl.pathname === '/health' || reqUrl.pathname.startsWith('/health/')) {
+    return next();
+  }
+  // Get forwarded IP header using Hono helper
+  const xff = c.req.header('x-forwarded-for');
+  const clientIp = xff ? xff.split(',')[0].trim() : (c.req.conn?.remoteAddr || '');
+
+  let allowed = false;
+  for (const range of MPESA_IP_RANGES) {
+    try {
+      const cidr = new CIDR(range);
+      if (cidr.contains(clientIp)) {
+        allowed = true;
+        break;
+      }
+    } catch (error) {
+      console.error(`Invalid CIDR range: ${range}`, error);
+      continue;
+    }
+  }
+
+  if (!allowed) {
+    console.warn(`🚫 IP validation failed for ${clientIp} - request blocked`);
+    return c.json({ error: 'Forbidden: IP not allowed' }, 403);
+  }
+
+  if (!allowed) {
+    return c.json({ error: 'Forbidden: IP not allowed' }, 403);
+  }
+
+  return next();
+}

--- a/webhook-service/src/server.ts
+++ b/webhook-service/src/server.ts
@@ -6,6 +6,7 @@ import { metricsRoutes } from "./routes/metricsRoutes";
 import { dlqRoutes } from "./routes/dlqRoutes";
 import userRetryRoutes from "./routes/userRetryRoutes";
 import { errorHandler, requestLogger } from "./middleware";
+import { ipValidator } from "./middleware/ipValidator";
 import db from "./drizzle/db";
 import { sql } from "drizzle-orm";
 import authRouter from "./routes/auth.routes";
@@ -23,6 +24,7 @@ app.use(cors({
 app.use("*", errorHandler);
 app.use("*", requestLogger);
 // app.use("*", cors());
+app.use("*", ipValidator);
 app.use("*", logger());
 
 // Routes


### PR DESCRIPTION
This pull request introduces an IP validation middleware to the `webhook-service` project, ensuring that requests are only allowed from specified IP ranges. It also updates dependencies and integrates the middleware into the server setup.

### Middleware for IP Validation:
* [`webhook-service/src/middleware/ipValidator.ts`](diffhunk://#diff-d59f4770f20487cd1e9cc3ebc203cda065cd94d66563e3faf654df0454c6061bR1-R54): Added an `ipValidator` middleware that checks incoming requests against allowed M-Pesa IP ranges defined in the `MPESA_IP_RANGES` environment variable. Requests from non-allowed IPs are blocked, except for health endpoints.

### Integration of Middleware:
* [`webhook-service/src/server.ts`](diffhunk://#diff-54a79503b52eac7579cea08ddff287a2b55d130922411ac67acc7b314de6519cR9): Imported the `ipValidator` middleware and applied it globally to all routes using `app.use("*", ipValidator)`. [[1]](diffhunk://#diff-54a79503b52eac7579cea08ddff287a2b55d130922411ac67acc7b314de6519cR9) [[2]](diffhunk://#diff-54a79503b52eac7579cea08ddff287a2b55d130922411ac67acc7b314de6519cR27)

### Dependency Update:
* [`webhook-service/package.json`](diffhunk://#diff-8c0a22e910c8ef773ce5182a80668068b7920e93520600d8e25c3c027f1afe08L25-R26): Added the `ip-cidr` package to handle CIDR-based IP range validation.